### PR TITLE
[WIP] Define operatorname function.

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -112,6 +112,15 @@ defineFunction("\\sqrt", {
     };
 });
 
+defineFunction("\\operatorname", {
+    numArgs: 1,
+}, function (context, args) {
+    return {
+        type: "operatorname",
+        body: args[0]
+    };
+});
+
 // Some non-mathy text
 defineFunction("\\text", {
     numArgs: 1,


### PR DESCRIPTION
Used for functions that aren't already in the system. For example, `\operatorname{sin}` is similar to `\sin` and `\operatorname{length}(x)` allows typesetting "length" as if it was a "known function".

TODO: define display behavior of this operator. So far, I have only added it to the parser.